### PR TITLE
Ajustements esthétiques avant mise en prod cachée

### DIFF
--- a/sso/tests.py
+++ b/sso/tests.py
@@ -16,6 +16,7 @@ class TestStaticPages(TestCase):
     def test_index_response_contains_welcome_message(self):
         response = self.client.get("/")
         self.assertContains(response, "Single Sign-On Opérateur")
+        self.assertContains(response, "Suite numérique collaborative")
 
     def test_a11y_url_calls_correct_view(self):
         match = resolve("/accessibilite/")

--- a/sso/tests.py
+++ b/sso/tests.py
@@ -45,5 +45,4 @@ class TestDSFR(TestCase):
         self.assertTemplateUsed(response, "dsfr/skiplinks.html")
         self.assertTemplateUsed(response, "dsfr/header.html")
         self.assertTemplateUsed(response, "dsfr/theme_modale.html")
-        self.assertTemplateUsed(response, "dsfr/breadcrumb.html")
         self.assertTemplateUsed(response, "dsfr/global_js.html")

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,9 +28,11 @@
     {% include "blocks/header.html" %}
     {% dsfr_theme_modale %}
 
-    <div class="fr-container fr-mt-4w fr-mb-6w">
-      {% dsfr_breadcrumb %}
+    <div class="fr-container">
+        {% dsfr_alert type="info" title="Avertissement" content="Ce service est encore en cours de test." %}
+      </div>
 
+    <div class="fr-container fr-mt-4w fr-mb-6w">
       <main id="content" role="main">
         {% block content %}{% endblock content %}
       </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,9 +13,9 @@
   {% block title %}
   <title>
     {% if title %}
-      {{ title }} — Design Système de l’État
+      {{ title }} — Suite numérique collaborative
     {% else %}
-      Design Système de l’État
+      Suite numérique collaborative
     {% endif %}
   </title>
   {% endblock title %}

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -1,5 +1,5 @@
 {% extends "dsfr/header.html" %}
-{% load dsfr_tags %}
+
 {% block service_title %}
 <a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
     <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }}</p>
@@ -36,9 +36,6 @@
 {# endblock burger_menu #}
 
 {% block main_menu %}
-    <div class="fr-container">
-        {% dsfr_alert type="info" title="Avertissement" content="Ce service est encore en cours de test." %}
-    </div>
     <div class="fr-header__menu fr-modal" id="fr-menu-mobile" aria-labelledby="fr-btn-menu-mobile">
       <div class="fr-container">
         <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-menu-mobile">Fermer</button>

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -1,5 +1,5 @@
 {% extends "dsfr/header.html" %}
-
+{% load dsfr_tags %}
 {% block service_title %}
 <a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
     <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }}</p>
@@ -36,6 +36,9 @@
 {# endblock burger_menu #}
 
 {% block main_menu %}
+    <div class="fr-container">
+        {% dsfr_alert type="info" title="Avertissement" content="Ce service est encore en cours de test." %}
+    </div>
     <div class="fr-header__menu fr-modal" id="fr-menu-mobile" aria-labelledby="fr-btn-menu-mobile">
       <div class="fr-container">
         <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-menu-mobile">Fermer</button>


### PR DESCRIPTION
## 🎯 Objectif

On va passer le projet sur l'environnement de prod, mais on sera toujours en mode beta test (voir alpha test).

À faire : 

- [x] Corriger le titre qui est actuellement "système de design de l'état"
- [x] Ajouter une bannière indiquant que le service est actuellement instable/en cours de test

## 🔍 Implémentation

- _Une liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

Je ne sais pas trop où la mettre…

![Capture d’écran 2023-09-27 à 16 34 41](https://github.com/numerique-gouv/sso-operateur/assets/1035145/10df935d-11d4-4752-8444-a9403b7c4fd6)


