### PR TITLE
Suppression de l'étape interactive pour aller vers MCP

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -156,7 +156,12 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
 
 CSP_DEFAULT_SRC = "'self'"
-CSP_STYLE_SRC = "'self' 'sha256-Eyt3MCqJJqqqUJzUlVq9BLYX+kVGQZVLpJ4toZz4mb8=' 'sha256-d//Lck7pNf/OY9MPfGYaIOTmqjEzvwlSukK3UObI08A=' 'sha256-28J4mQEy4Sqd0R+nZ89dOl9euh+Y3XvT+VfXD5pOiOE='"
+CSP_STYLE_SRC = (
+    "'self'",
+    "'sha256-Eyt3MCqJJqqqUJzUlVq9BLYX+kVGQZVLpJ4toZz4mb8='",
+    "'sha256-d//Lck7pNf/OY9MPfGYaIOTmqjEzvwlSukK3UObI08A='",
+    "'sha256-28J4mQEy4Sqd0R+nZ89dOl9euh+Y3XvT+VfXD5pOiOE='",
+)
 CSP_IMG_SRC = "'self' data:"
 CSP_SCRIPT_SRC = [
     "'self'",

--- a/config/settings.py
+++ b/config/settings.py
@@ -166,6 +166,7 @@ CSP_IMG_SRC = "'self' data:"
 CSP_SCRIPT_SRC = [
     "'self'",
     "'sha256-a28Komkyw2vnuwMdBLFFY3y1uJCXIFk2nAOcCqEWkf4='",  # sso/templates/sso/oidc/multi-login.html
+    "'sha256-clj2y3uU8vgOElks1xzuZ4AMo04erou4FAxsbT9OCas='",  # templates/registration/login.html
 ]
 REFERRER_POLICY = "same-origin"
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -4,10 +4,10 @@
 
     <h1>Connexion</h1>
     {% if user.is_authenticated %}
-        <p>Current user: {{ user.email }}</p>
+        <p>Vous êtes déjà connecté(e) avec l'e-mail : {{ user.email }}</p>
         <form action="{% url 'oidc_logout' %}" method="post">
             {% csrf_token %}
-            <input type="submit" value="logout">
+            <button class="fr-btn" type="submit" value="logout">Se déconnecter</button>
         </form>
     {% else %}
         <form action="{% url 'oidc_authentication_init' %}" method="get" id="init_oidc_form">

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -9,21 +9,28 @@
             {% csrf_token %}
             <input type="submit" value="logout">
         </form>
-    {% else %}      
-        <form action="{% url 'oidc_authentication_init' %}" method="get">
+    {% else %}
+        <form action="{% url 'oidc_authentication_init' %}" method="get" id="init_oidc_form">
             <div class="fr-connect-group">
+                <p>Vous allez vous connecter à la suite numérique avec MonComptePro.</p>
+                <p>Si rien ne se passe, cliquez sur le bouton :</p>
                 <button type="submit" class="fr-connect">
                     <span class="fr-connect__login">S’identifier avec</span>
                     <span class="fr-connect__brand">MonComptePro</span>
                 </button>
                 <input type="hidden" name="next" value="{{ next }}">
                 <p>
-                    <a href="https://moncomptepro.beta.gouv.fr/" target="_blank"  rel="noopener" title="Qu’est-ce que Mon compte pro ? - nouvelle fenêtre">Qu’est-ce que MonComptePro ?</a>
+                    <a href="https://moncomptepro.beta.gouv.fr/" target="_blank" rel="noopener"
+                       title="Qu’est-ce que Mon compte pro ? - nouvelle fenêtre">Qu’est-ce que MonComptePro ?</a>
                 </p>
             </div>
         </form>
     {% endif %}
-
-
-    
+{% endblock %}
+{% block extra_js %}
+    <script>
+        setTimeout(function () {
+            document.getElementById("init_oidc_form").submit();
+        }, 0);
+    </script>
 {% endblock %}


### PR DESCRIPTION
## 🎯 Objectif

Éviter une action "inutile" à l'utilisateur : cliquer sur le bouton "Se connecter à mon compte pro"

Je propose de faire le travail à sa place, en lui expliquant s'il/elle a le temps de lire le message…

## 🔍 Implémentation

- Ajout d'un bout de JS qui va soumettre le formulaire une fois que la page est chargée.
- On pourrait aussi rediriger directement vers MCP lorsque l'usager arrive sur la page de login, mais il faut veiller à bien garder le paramètre `next` et je n'ai pas l'impression qu'il y ait de moyen propre de faire ça. Je me dis aussi que ça peut être intéressant de bien montrer à l'usager-e qu'iel se connecte à la suite numérique.

## 🏕 Amélioration continue

- J'en ai profité pour modifier le message "déjà connecté".
- Je me suis d'abord appliquée à ajouter le hash de mon JS dans la variable `CSP_STYLE_SRC`, c'est pour ça qu'elle est toute joliment formatée… Hum hum pardon.

## 🖼️ Images

On est d'accord que c'est minuscule comme police d'écriture ? Je ne sais pas ce que j'ai fait de mal pour obtenir ça.

![Capture d’écran 2023-10-02 à 15 59 01](https://github.com/numerique-gouv/sso-operateur/assets/1035145/517d9d4e-551a-4e49-af6a-18fdc8510dc6)


